### PR TITLE
Make compatible with Node versions up to 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - "16"
   - "14"
   - "12"
   - "11"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ node_js:
   - "0.11"
   - "4.2"
   - "5.2"
-  - "iojs"
 install:
 - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - "14"
   - "12"
   - "11"
   - "10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - "12"
   - "11"
   - "10"
   - "9"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/dmitrymyadzelets/node-glpk.svg?branch=node-v12)](https://travis-ci.org/dmitrymyadzelets/node-glpk)
+[![Build Status](https://travis-ci.org/dmitrymyadzelets/node-glpk.svg?branch=master)](https://travis-ci.org/dmitrymyadzelets/node-glpk)
 # node-glpk
 Node.js native module for GLPK.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/dmitrymyadzelets/node-glpk.svg?branch=master)](https://travis-ci.org/dmitrymyadzelets/node-glpk)
+[![Build Status](https://travis-ci.org/hgourvest/node-glpk.svg?branch=master)](https://travis-ci.org/hgourvest/node-glpk)
 # node-glpk
 Node.js native module for GLPK.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/hgourvest/node-glpk.svg?branch=master)](https://travis-ci.org/hgourvest/node-glpk)
+[![Build Status](https://travis-ci.org/dmitrymyadzelets/node-glpk.svg?branch=node-v12)](https://travis-ci.org/dmitrymyadzelets/node-glpk)
 # node-glpk
 Node.js native module for GLPK.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "engines": {
         "iojs": "*",
-        "node": ">=0.11.0 <=12.x"
+        "node": ">=0.11.0 <=14.x"
       }
     },
     "node_modules/bindings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "engines": {
         "iojs": "*",
-        "node": ">=0.11.0 <=11.x"
+        "node": ">=0.11.0 <=12.x"
       }
     },
     "node_modules/bindings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "engines": {
         "iojs": "*",
-        "node": ">=0.11.0 <=14.x"
+        "node": ">=0.11.0 <=16.x"
       }
     },
     "node_modules/bindings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "glpk",
+  "version": "0.0.13",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "glpk",
+      "version": "0.0.13",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "bindings": "^1.2.1",
+        "nan": "^2.1.0"
+      },
+      "engines": {
+        "iojs": "*",
+        "node": ">=0.11.0 <=11.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.14.0",
+      "license": "MIT"
+    }
+  },
+  "dependencies": {
+    "bindings": {
+      "version": "1.5.0",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0"
+    },
+    "nan": {
+      "version": "2.14.0"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glpk",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "glpk",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "MPL-2.0",
       "dependencies": {
         "bindings": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "bindings": "^1.2.1",
-        "nan": "^2.1.0"
+        "nan": "^2.14.0"
       },
       "engines": {
         "iojs": "*",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   ],
    "repository": {
     "type": "git",
-    "url": "git://github.com/hgourvest/node-glpk.git"
+    "url": "git://github.com/hgourvest/node-glpk.git",
+    "test": "echo \"Info: no test specified\" && exit 0"
   },
   "homepage": "http://github.com/hgourvest/node-glpk",
   "description": "Node.js native module for GLPK.",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "scripts": {
     "configure": "node-gyp configure",
-    "build": "node-gyp build"
+    "build": "node-gyp build",
+    "test": "echo \"Info: no test specified\" && exit 0"
   },
   "engines" : { "node" : ">=0.11.0 <=16.x", "iojs": "*" }
 }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,5 @@
     "configure": "node-gyp configure",
     "build": "node-gyp build"
   },
-  "engines" : { "node" : ">=0.11.0 <=11.x", "iojs": "*" }
+  "engines" : { "node" : ">=0.11.0 <=12.x", "iojs": "*" }
 }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,5 @@
     "configure": "node-gyp configure",
     "build": "node-gyp build"
   },
-  "engines" : { "node" : ">=0.11.0 <=14.x", "iojs": "*" }
+  "engines" : { "node" : ">=0.11.0 <=16.x", "iojs": "*" }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "glpk"
     ],
   "dependencies": {
-    "nan": "^2.1.0",
+    "nan": "^2.14.0",
     "bindings": "^1.2.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,5 +23,5 @@
     "configure": "node-gyp configure",
     "build": "node-gyp build"
   },
-  "engines" : { "node" : ">=0.11.0 <=12.x", "iojs": "*" }
+  "engines" : { "node" : ">=0.11.0 <=14.x", "iojs": "*" }
 }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   },
   "scripts": {
     "configure": "node-gyp configure",
-    "build": "node-gyp build",
-    "test": "echo \"Info: no test specified\" && exit 0"
+    "build": "node-gyp build"
   },
   "engines" : { "node" : ">=0.11.0 <=16.x", "iojs": "*" }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glpk",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "license": "MPL-2.0",
   "main": "index.js",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   ],
    "repository": {
     "type": "git",
-    "url": "git://github.com/hgourvest/node-glpk.git",
-    "test": "echo \"Info: no test specified\" && exit 0"
+    "url": "git://github.com/hgourvest/node-glpk.git"
   },
   "homepage": "http://github.com/hgourvest/node-glpk",
   "description": "Node.js native module for GLPK.",

--- a/src/common.h
+++ b/src/common.h
@@ -10,8 +10,9 @@
 #define _common_h
 
 #include <nan.h>
+#include <nan_converters_43_inl.h>
 
-#define V8TOCSTRING(S) (*String::Utf8Value(S->ToString()))
+#define V8TOCSTRING(S) (*Nan::Utf8String(S))
 
 #define V8CHECK(T, E) if (T) { \
     Nan::ThrowTypeError(E);\
@@ -76,7 +77,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value());)\
+    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust());)\
 }
 
 #define GLP_BIND_VALUE(CLASS, NAME, API)\
@@ -97,7 +98,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), V8TOCSTRING(info[1]));)\
+    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), V8TOCSTRING(info[1]));)\
 }
 
 #define GLP_BIND_STR_INT32(CLASS, NAME, API);\
@@ -109,7 +110,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(const char* name = API(host->handle, info[0]->Int32Value());\
+    GLP_CATCH_RET(const char* name = API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust());\
     if (name)\
         info.GetReturnValue().Set(Nan::New<String>(name).ToLocalChecked());\
     else\
@@ -126,7 +127,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->Int32Value(),\
+    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), info[1]->Int32Value(Nan::GetCurrentContext()).FromJust(),\
                      info[2]->NumberValue(), info[3]->NumberValue());)\
 }
 
@@ -139,7 +140,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->NumberValue());)\
+    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), info[1]->NumberValue());)\
 }
 
 #define GLP_BIND_VALUE_INT32(CLASS, NAME, API)\
@@ -151,7 +152,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, info[0]->Int32Value()));)\
+    GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust()));)\
 }
 
 #define GLP_BIND_VOID_INT32_INT32ARRAY_FLOAT64ARRAY(CLASS, NAME, API)\
@@ -173,10 +174,10 @@ static NAN_METHOD(NAME) {\
     int* pja = (int*)malloc(ja->Length() * sizeof(int));\
     double* par = (double*)malloc(ar->Length() * sizeof(double));\
     \
-    for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(i)->Int32Value();\
+    for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(i)->Int32Value(Nan::GetCurrentContext()).FromJust();\
     for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(i)->NumberValue();\
     \
-    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), count, pja, par);)\
+    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), count, pja, par);)\
     \
     free(pja);\
     free(par);\
@@ -192,7 +193,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
     try{\
-        int row = info[0]->Int32Value();\
+        int row = info[0]->Int32Value(Nan::GetCurrentContext()).FromJust();\
         int count = API(host->handle, row, NULL, NULL);\
         \
         if ((info.Length() == 2) && (info[1]->IsFunction())) {\
@@ -238,7 +239,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(count <= 1, "Invalid Array size");\
     \
     int* idx = (int*)malloc(count * sizeof(int));\
-    for (int i = 0; i < count; i++) idx[i] = num->Get(i)->Int32Value();\
+    for (int i = 0; i < count; i++) idx[i] = num->Get(i)->Int32Value(Nan::GetCurrentContext()).FromJust();\
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
@@ -269,7 +270,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->Int32Value());)\
+    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), info[1]->Int32Value(Nan::GetCurrentContext()).FromJust());)\
 }
 
 #define GLP_BIND_VALUE_INT32_STR(CLASS, NAME, API)\
@@ -281,7 +282,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, info[0]->Int32Value(), V8TOCSTRING(info[1])));)\
+    GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), V8TOCSTRING(info[1])));)\
 }
 
 #define GLP_BIND_VALUE_STR_INT32(CLASS, NAME, API)\
@@ -293,7 +294,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, V8TOCSTRING(info[0]), info[1]->Int32Value()));)\
+    GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, V8TOCSTRING(info[0]), info[1]->Int32Value(Nan::GetCurrentContext()).FromJust()));)\
 }
 
 #define GLP_BIND_DELETE(CLASS, NAME, API)\
@@ -396,7 +397,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(lp->thread, "an async operation is inprogress")\
     \
     Nan::Callback *callback = new Nan::Callback(info[2].As<Function>());\
-    NAME##Worker *worker = new NAME##Worker(callback, lp, info[0]->Int32Value(), V8TOCSTRING(info[1]));\
+    NAME##Worker *worker = new NAME##Worker(callback, lp, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), V8TOCSTRING(info[1]));\
     lp->thread = true;\
     Nan::AsyncQueueWorker(worker);\
 }\

--- a/src/common.h
+++ b/src/common.h
@@ -193,8 +193,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
     try{\
-        Local<Context> context = Nan::GetCurrentContext();\
-        int row = info[0]->Int32Value(context).FromJust();\
+        int row = info[0]->Int32Value(Nan::GetCurrentContext()).FromJust();\
         int count = API(host->handle, row, NULL, NULL);\
         \
         if ((info.Length() == 2) && (info[1]->IsFunction())) {\
@@ -203,15 +202,15 @@ static NAN_METHOD(NAME) {\
             API(host->handle, row, idx, val);\
             Local<Int32Array> ja = Int32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), sizeof(int) * (count+1)), 0, count + 1);\
             Local<Float64Array> ar = Float64Array::New(ArrayBuffer::New(Isolate::GetCurrent(), sizeof(double) * (count+1)), 0, count + 1);\
-        	for (int i = 1; i <= count; i++) ja->Set(context, (uint32_t)i, Int32::New(Isolate::GetCurrent(), idx[i])).Check();\
-        	for (int i = 1; i <= count; i++) ar->Set(context, (uint32_t)i, Number::New(Isolate::GetCurrent(), val[i])).Check();\
+        	for (int i = 1; i <= count; i++) Nan::Set(ja, (uint32_t)i, Int32::New(Isolate::GetCurrent(), idx[i])).Check();\
+        	for (int i = 1; i <= count; i++) Nan::Set(ar, (uint32_t)i, Number::New(Isolate::GetCurrent(), val[i])).Check();\
         	free(idx);\
         	free(val);\
             \
             Local<Function> cb = Local<Function>::Cast(info[1]);\
             const unsigned argc = 2;\
             Local<Value> argv[argc] = {ja, ar};\
-            Nan::Call(cb, context->Global(), argc, argv);\
+            Nan::Call(cb, Nan::GetCurrentContext()->Global(), argc, argv);\
             info.GetReturnValue().Set(count);\
         }\
     } catch (std::string s) {\
@@ -311,10 +310,10 @@ static NAN_METHOD(NAME) {\
 }
 
 #define GLP_SET_FIELD_INT32(OBJ, KEY, VALUE)\
-OBJ->Set(Nan::GetCurrentContext(), Nan::New<String>(KEY).ToLocalChecked(), Nan::New<Int32>(VALUE)).Check();
+Nan::Set(OBJ, Nan::New<String>(KEY).ToLocalChecked(), Nan::New<Int32>(VALUE)).Check();
 
 #define GLP_SET_FIELD_DOUBLE(OBJ, KEY, VALUE)\
-OBJ->Set(Nan::GetCurrentContext(), Nan::New<String>(KEY).ToLocalChecked(), Nan::New<Number>(VALUE)).Check();
+Nan::Set(OBJ, Nan::New<String>(KEY).ToLocalChecked(), Nan::New<Number>(VALUE)).Check();
 
 
 #define GLP_ASYNC_INT32_STR(CLASS, NAME, API)\

--- a/src/common.h
+++ b/src/common.h
@@ -33,7 +33,7 @@
 do {\
 Isolate* isolate = Isolate::GetCurrent();\
 Local<String> constant_name =\
-String::NewFromUtf8(isolate, #name);\
+String::NewFromUtf8(isolate, #name, NewStringType::kNormal).ToLocalChecked();\
 Local<Number> constant_value =\
 Number::New(isolate, static_cast<double>(constant));\
 PropertyAttribute constant_attributes =\

--- a/src/common.h
+++ b/src/common.h
@@ -209,7 +209,7 @@ static NAN_METHOD(NAME) {\
             Local<Function> cb = Local<Function>::Cast(info[1]);\
             const unsigned argc = 2;\
             Local<Value> argv[argc] = {ja, ar};\
-            cb->Call(Isolate::GetCurrent()->GetCurrentContext()->Global(), argc, argv);\
+            Nan::Call(cb, Isolate::GetCurrent()->GetCurrentContext()->Global(), argc, argv);\
             info.GetReturnValue().Set(count);\
         }\
     } catch (std::string s) {\

--- a/src/common.h
+++ b/src/common.h
@@ -201,8 +201,8 @@ static NAN_METHOD(NAME) {\
             API(host->handle, row, idx, val);\
             Local<Int32Array> ja = Int32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), sizeof(int) * (count+1)), 0, count + 1);\
             Local<Float64Array> ar = Float64Array::New(ArrayBuffer::New(Isolate::GetCurrent(), sizeof(double) * (count+1)), 0, count + 1);\
-        	for (int i = 1; i <= count; i++) ja->Set((uint32_t)i, Int32::New(Isolate::GetCurrent(), idx[i]));\
-        	for (int i = 1; i <= count; i++) ar->Set((uint32_t)i, Number::New(Isolate::GetCurrent(), val[i]));\
+        	for (int i = 1; i <= count; i++) ja->Set(Nan::GetCurrentContext(), (uint32_t)i, Int32::New(Isolate::GetCurrent(), idx[i])).Check();\
+        	for (int i = 1; i <= count; i++) ar->Set(Nan::GetCurrentContext(), (uint32_t)i, Number::New(Isolate::GetCurrent(), val[i])).Check();\
         	free(idx);\
         	free(val);\
             \
@@ -307,10 +307,10 @@ static NAN_METHOD(NAME) {\
 }
 
 #define GLP_SET_FIELD_INT32(OBJ, KEY, VALUE)\
-OBJ->Set(Nan::New<String>(KEY).ToLocalChecked(), Nan::New<Int32>(VALUE));
+OBJ->Set(Nan::GetCurrentContext(), Nan::New<String>(KEY).ToLocalChecked(), Nan::New<Int32>(VALUE)).Check();
 
 #define GLP_SET_FIELD_DOUBLE(OBJ, KEY, VALUE)\
-OBJ->Set(Nan::New<String>(KEY).ToLocalChecked(), Nan::New<Number>(VALUE));
+OBJ->Set(Nan::GetCurrentContext(), Nan::New<String>(KEY).ToLocalChecked(), Nan::New<Number>(VALUE)).Check();
 
 
 #define GLP_ASYNC_INT32_STR(CLASS, NAME, API)\

--- a/src/common.h
+++ b/src/common.h
@@ -334,7 +334,7 @@ void WorkComplete() {\
 }\
 virtual void HandleOKCallback() {\
     Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};\
-    callback->Call(2, info);\
+    callback->Call(2, info, async_resource);\
 }\
 \
 public:\
@@ -378,7 +378,7 @@ public:\
     \
     virtual void HandleOKCallback() {\
         Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};\
-        callback->Call(2, info);\
+        callback->Call(2, info, async_resource);\
     }\
     \
 public:\

--- a/src/common.h
+++ b/src/common.h
@@ -10,7 +10,6 @@
 #define _common_h
 
 #include <nan.h>
-#include <nan_converters_43_inl.h>
 
 #define V8TOCSTRING(S) (*Nan::Utf8String(S))
 

--- a/src/common.h
+++ b/src/common.h
@@ -174,10 +174,10 @@ static NAN_METHOD(NAME) {\
     double* par = (double*)malloc(ar->Length() * sizeof(double));\
     Local<Context> context = Nan::GetCurrentContext();\
     \
-    for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(context, i).ToLocalChecked()->Int32Value(Nan::GetCurrentContext()).FromJust();\
-    for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(context, i).ToLocalChecked()->NumberValue(Nan::GetCurrentContext()).FromJust();\
+    for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(context, i).ToLocalChecked()->Int32Value(context).FromJust();\
+    for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(context, i).ToLocalChecked()->NumberValue(context).FromJust();\
     \
-    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), count, pja, par);)\
+    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(context).FromJust(), count, pja, par);)\
     \
     free(pja);\
     free(par);\
@@ -193,7 +193,8 @@ static NAN_METHOD(NAME) {\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
     try{\
-        int row = info[0]->Int32Value(Nan::GetCurrentContext()).FromJust();\
+        Local<Context> context = Nan::GetCurrentContext();\
+        int row = info[0]->Int32Value(context).FromJust();\
         int count = API(host->handle, row, NULL, NULL);\
         \
         if ((info.Length() == 2) && (info[1]->IsFunction())) {\
@@ -202,15 +203,15 @@ static NAN_METHOD(NAME) {\
             API(host->handle, row, idx, val);\
             Local<Int32Array> ja = Int32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), sizeof(int) * (count+1)), 0, count + 1);\
             Local<Float64Array> ar = Float64Array::New(ArrayBuffer::New(Isolate::GetCurrent(), sizeof(double) * (count+1)), 0, count + 1);\
-        	for (int i = 1; i <= count; i++) ja->Set(Nan::GetCurrentContext(), (uint32_t)i, Int32::New(Isolate::GetCurrent(), idx[i])).Check();\
-        	for (int i = 1; i <= count; i++) ar->Set(Nan::GetCurrentContext(), (uint32_t)i, Number::New(Isolate::GetCurrent(), val[i])).Check();\
+        	for (int i = 1; i <= count; i++) ja->Set(context, (uint32_t)i, Int32::New(Isolate::GetCurrent(), idx[i])).Check();\
+        	for (int i = 1; i <= count; i++) ar->Set(context, (uint32_t)i, Number::New(Isolate::GetCurrent(), val[i])).Check();\
         	free(idx);\
         	free(val);\
             \
             Local<Function> cb = Local<Function>::Cast(info[1]);\
             const unsigned argc = 2;\
             Local<Value> argv[argc] = {ja, ar};\
-            Nan::Call(cb, Isolate::GetCurrent()->GetCurrentContext()->Global(), argc, argv);\
+            Nan::Call(cb, context->Global(), argc, argv);\
             info.GetReturnValue().Set(count);\
         }\
     } catch (std::string s) {\
@@ -240,7 +241,7 @@ static NAN_METHOD(NAME) {\
     \
     int* idx = (int*)malloc(count * sizeof(int));\
     Local<Context> context = Nan::GetCurrentContext();\
-    for (int i = 0; i < count; i++) idx[i] = num->Get(context, i).ToLocalChecked()->Int32Value(Nan::GetCurrentContext()).FromJust();\
+    for (int i = 0; i < count; i++) idx[i] = num->Get(context, i).ToLocalChecked()->Int32Value(context).FromJust();\
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
@@ -271,7 +272,8 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), info[1]->Int32Value(Nan::GetCurrentContext()).FromJust());)\
+    Local<Context> context = Nan::GetCurrentContext();\
+    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(context).FromJust(), info[1]->Int32Value(context).FromJust());)\
 }
 
 #define GLP_BIND_VALUE_INT32_STR(CLASS, NAME, API)\

--- a/src/common.h
+++ b/src/common.h
@@ -172,9 +172,10 @@ static NAN_METHOD(NAME) {\
     \
     int* pja = (int*)malloc(ja->Length() * sizeof(int));\
     double* par = (double*)malloc(ar->Length() * sizeof(double));\
+    Local<Context> context = Nan::GetCurrentContext();\
     \
-    for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(i)->Int32Value(Nan::GetCurrentContext()).FromJust();\
-    for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(i)->NumberValue(Nan::GetCurrentContext()).FromJust();\
+    for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(context, i).ToLocalChecked()->Int32Value(Nan::GetCurrentContext()).FromJust();\
+    for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(context, i).ToLocalChecked()->NumberValue(Nan::GetCurrentContext()).FromJust();\
     \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), count, pja, par);)\
     \
@@ -238,7 +239,8 @@ static NAN_METHOD(NAME) {\
     V8CHECK(count <= 1, "Invalid Array size");\
     \
     int* idx = (int*)malloc(count * sizeof(int));\
-    for (int i = 0; i < count; i++) idx[i] = num->Get(i)->Int32Value(Nan::GetCurrentContext()).FromJust();\
+    Local<Context> context = Nan::GetCurrentContext();\
+    for (int i = 0; i < count; i++) idx[i] = num->Get(context, i).ToLocalChecked()->Int32Value(Nan::GetCurrentContext()).FromJust();\
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\

--- a/src/common.h
+++ b/src/common.h
@@ -128,7 +128,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), info[1]->Int32Value(Nan::GetCurrentContext()).FromJust(),\
-                     info[2]->NumberValue(), info[3]->NumberValue());)\
+                     info[2]->NumberValue(Nan::GetCurrentContext()).FromJust(), info[3]->NumberValue(Nan::GetCurrentContext()).FromJust());)\
 }
 
 #define GLP_BIND_VOID_INT32_DOUBLE(CLASS, NAME, API)\
@@ -140,7 +140,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), info[1]->NumberValue());)\
+    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), info[1]->NumberValue(Nan::GetCurrentContext()).FromJust());)\
 }
 
 #define GLP_BIND_VALUE_INT32(CLASS, NAME, API)\
@@ -175,7 +175,7 @@ static NAN_METHOD(NAME) {\
     double* par = (double*)malloc(ar->Length() * sizeof(double));\
     \
     for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(i)->Int32Value(Nan::GetCurrentContext()).FromJust();\
-    for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(i)->NumberValue();\
+    for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(i)->NumberValue(Nan::GetCurrentContext()).FromJust();\
     \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), count, pja, par);)\
     \

--- a/src/mathprog.hpp
+++ b/src/mathprog.hpp
@@ -11,7 +11,7 @@ namespace NodeGLPK {
 
     class Mathprog : public node::ObjectWrap {
     public:
-        static void Init(Handle<Object> exports){
+        static void Init(Local<Object> exports){
             // Prepare constructor template
             Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
             tpl->SetClassName(Nan::New<String>("Mathprog").ToLocalChecked());

--- a/src/mathprog.hpp
+++ b/src/mathprog.hpp
@@ -34,7 +34,7 @@ namespace NodeGLPK {
             
             constructor.Reset(tpl);
 
-            exports->Set(Nan::New<String>("Mathprog").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
+            exports->Set(Nan::GetCurrentContext(), Nan::New<String>("Mathprog").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked()).Check();
         }
     private:
         explicit Mathprog(): node::ObjectWrap(){

--- a/src/mathprog.hpp
+++ b/src/mathprog.hpp
@@ -237,7 +237,7 @@ namespace NodeGLPK {
             V8CHECK(!mp->handle, "object deleted");
             V8CHECK(mp->thread, "an async operation is inprogress");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(info[0]->ToObject());
+            Problem* lp = ObjectWrap::Unwrap<Problem>(Nan::To<Object>(info[0]).ToLocalChecked());
             V8CHECK(!lp || !lp->handle, "invalid problem");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
@@ -257,7 +257,7 @@ namespace NodeGLPK {
             V8CHECK(!mp->handle, "object deleted");
             V8CHECK(mp->thread, "an async operation is inprogress");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(info[0]->ToObject());
+            Problem* lp = ObjectWrap::Unwrap<Problem>(Nan::To<Object>(info[0]).ToLocalChecked());
             V8CHECK(!lp || !lp->handle, "invalid problem");
             
             GLP_CATCH_RET(glp_mpl_build_prob(mp->handle, lp->handle);)
@@ -299,7 +299,7 @@ namespace NodeGLPK {
             V8CHECK(!mp->handle, "object deleted");
             V8CHECK(mp->thread, "an async operation is inprogress");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(info[0]->ToObject());
+            Problem* lp = ObjectWrap::Unwrap<Problem>(Nan::To<Object>(info[0]).ToLocalChecked());
             V8CHECK(!lp || !lp->handle, "invalid problem");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
@@ -317,7 +317,7 @@ namespace NodeGLPK {
             V8CHECK(!mp->handle, "object deleted");
             V8CHECK(mp->thread, "an async operation is inprogress");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(info[0]->ToObject());
+            Problem* lp = ObjectWrap::Unwrap<Problem>(Nan::To<Object>(info[0]).ToLocalChecked());
             V8CHECK(!lp || !lp->handle, "invalid problem");
             
             GLP_CATCH_RET(info.GetReturnValue().Set(glp_mpl_postsolve(mp->handle, lp->handle, info[1]->Int32Value(Nan::GetCurrentContext()).FromJust()));)

--- a/src/mathprog.hpp
+++ b/src/mathprog.hpp
@@ -91,7 +91,7 @@ namespace NodeGLPK {
             V8CHECK(mp->thread, "an async operation is inprogress");
             
             Nan::Callback *callback = new Nan::Callback(info[2].As<Function>());
-            ReadModelWorker *worker = new ReadModelWorker(callback, mp, V8TOCSTRING(info[0]), info[1]->Int32Value());
+            ReadModelWorker *worker = new ReadModelWorker(callback, mp, V8TOCSTRING(info[0]), info[1]->Int32Value(Nan::GetCurrentContext()).FromJust());
             mp->thread = true;
             Nan::AsyncQueueWorker(worker);
         }
@@ -303,7 +303,7 @@ namespace NodeGLPK {
             V8CHECK(lp->thread, "an async operation is inprogress");
             
             Nan::Callback *callback = new Nan::Callback(info[2].As<Function>());
-            PostsolveWorker *worker = new PostsolveWorker(callback, mp, lp, info[1]->Int32Value());
+            PostsolveWorker *worker = new PostsolveWorker(callback, mp, lp, info[1]->Int32Value(Nan::GetCurrentContext()).FromJust());
             mp->thread = true;
             Nan::AsyncQueueWorker(worker);
         }
@@ -319,7 +319,7 @@ namespace NodeGLPK {
             Problem* lp = ObjectWrap::Unwrap<Problem>(info[0]->ToObject());
             V8CHECK(!lp || !lp->handle, "invalid problem");
             
-            GLP_CATCH_RET(info.GetReturnValue().Set(glp_mpl_postsolve(mp->handle, lp->handle, info[1]->Int32Value()));)
+            GLP_CATCH_RET(info.GetReturnValue().Set(glp_mpl_postsolve(mp->handle, lp->handle, info[1]->Int32Value(Nan::GetCurrentContext()).FromJust()));)
         }
         
         static NAN_METHOD(getLine){

--- a/src/mathprog.hpp
+++ b/src/mathprog.hpp
@@ -33,7 +33,8 @@ namespace NodeGLPK {
             Nan::SetPrototypeMethod(tpl, "getLastError", getLastError);
             
             constructor.Reset(tpl);
-            exports->Set(Nan::New<String>("Mathprog").ToLocalChecked(), tpl->GetFunction());
+
+            exports->Set(Nan::New<String>("Mathprog").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
         }
     private:
         explicit Mathprog(): node::ObjectWrap(){

--- a/src/mathprog.hpp
+++ b/src/mathprog.hpp
@@ -75,7 +75,7 @@ namespace NodeGLPK {
             }
             virtual void HandleOKCallback() {
                 Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
-                callback->Call(2, info);
+                callback->Call(2, info, async_resource);
             }
             public:
                 Mathprog *mp;
@@ -118,7 +118,7 @@ namespace NodeGLPK {
             }
             virtual void HandleOKCallback() {
                 Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
-                callback->Call(2, info);
+                callback->Call(2, info, async_resource);
             }
         public:
             Mathprog *mp;
@@ -164,7 +164,7 @@ namespace NodeGLPK {
             }
             virtual void HandleOKCallback() {
                 Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
-                callback->Call(2, info);
+                callback->Call(2, info, async_resource);
             }
             
         public:
@@ -283,7 +283,7 @@ namespace NodeGLPK {
             }
             virtual void HandleOKCallback() {
                 Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
-                callback->Call(2, info);
+                callback->Call(2, info, async_resource);
             }
         public:
             Mathprog *mp;

--- a/src/mathprog.hpp
+++ b/src/mathprog.hpp
@@ -34,7 +34,7 @@ namespace NodeGLPK {
             
             constructor.Reset(tpl);
 
-            exports->Set(Nan::GetCurrentContext(), Nan::New<String>("Mathprog").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked()).Check();
+            Nan::Set(exports, Nan::New<String>("Mathprog").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked()).Check();
         }
     private:
         explicit Mathprog(): node::ObjectWrap(){

--- a/src/nodeglpk.cc
+++ b/src/nodeglpk.cc
@@ -31,7 +31,7 @@ extern "C" {
         }
     }
     
-    void Init(Handle<Object> exports) {
+    void Init(Local<Object> exports) {
         glp_error_hook(_ErrorHook);
 
         exports->Set(Nan::New<String>("termOutput").ToLocalChecked(), Nan::New<FunctionTemplate>(TermOutput)->GetFunction());

--- a/src/nodeglpk.cc
+++ b/src/nodeglpk.cc
@@ -34,7 +34,7 @@ extern "C" {
     void Init(Local<Object> exports) {
         glp_error_hook(_ErrorHook);
 
-        exports->Set(Nan::New<String>("termOutput").ToLocalChecked(), Nan::GetFunction(Nan::New<FunctionTemplate>(TermOutput)).ToLocalChecked());
+        exports->Set(Nan::GetCurrentContext(), Nan::New<String>("termOutput").ToLocalChecked(), Nan::GetFunction(Nan::New<FunctionTemplate>(TermOutput)).ToLocalChecked()).Check();
         
         GLP_DEFINE_CONSTANT(exports, GLP_MAJOR_VERSION, MAJOR_VERSION);
         GLP_DEFINE_CONSTANT(exports, GLP_MINOR_VERSION, MINOR_VERSION);

--- a/src/nodeglpk.cc
+++ b/src/nodeglpk.cc
@@ -24,7 +24,7 @@ extern "C" {
         V8CHECK(info.Length() != 1, "Wrong number of arguments");
         V8CHECK(!info[0]->IsBoolean(), "Wrong arguments");
         
-        if (info[0]->BooleanValue()) {
+        if (Nan::To<bool>(info[0]).ToChecked()) {
             GLP_CATCH_RET(glp_term_hook(_TermHook);)
         } else {
             GLP_CATCH_RET(glp_term_hook(NULL);)

--- a/src/nodeglpk.cc
+++ b/src/nodeglpk.cc
@@ -34,7 +34,7 @@ extern "C" {
     void Init(Local<Object> exports) {
         glp_error_hook(_ErrorHook);
 
-        exports->Set(Nan::GetCurrentContext(), Nan::New<String>("termOutput").ToLocalChecked(), Nan::GetFunction(Nan::New<FunctionTemplate>(TermOutput)).ToLocalChecked()).Check();
+        Nan::Set(exports, Nan::New<String>("termOutput").ToLocalChecked(), Nan::GetFunction(Nan::New<FunctionTemplate>(TermOutput)).ToLocalChecked()).Check();
         
         GLP_DEFINE_CONSTANT(exports, GLP_MAJOR_VERSION, MAJOR_VERSION);
         GLP_DEFINE_CONSTANT(exports, GLP_MINOR_VERSION, MINOR_VERSION);

--- a/src/nodeglpk.cc
+++ b/src/nodeglpk.cc
@@ -34,7 +34,7 @@ extern "C" {
     void Init(Local<Object> exports) {
         glp_error_hook(_ErrorHook);
 
-        exports->Set(Nan::New<String>("termOutput").ToLocalChecked(), Nan::New<FunctionTemplate>(TermOutput)->GetFunction());
+        exports->Set(Nan::New<String>("termOutput").ToLocalChecked(), Nan::GetFunction(Nan::New<FunctionTemplate>(TermOutput)).ToLocalChecked());
         
         GLP_DEFINE_CONSTANT(exports, GLP_MAJOR_VERSION, MAJOR_VERSION);
         GLP_DEFINE_CONSTANT(exports, GLP_MINOR_VERSION, MINOR_VERSION);

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -152,7 +152,7 @@ namespace NodeGLPK {
             
             constructor.Reset(tpl);
 
-            exports->Set(Nan::GetCurrentContext(), Nan::New<String>("Problem").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked()).Check();
+            Nan::Set(exports, Nan::New<String>("Problem").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked()).Check();
         }
         
         static bool SmcpInit(glp_smcp* scmp, Local<Value> value){

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -166,46 +166,46 @@ namespace NodeGLPK {
                 std::string keystr = std::string(V8TOCSTRING(key));
                 if (keystr == "msgLev"){
                     V8CHECKBOOL(!val->IsInt32(), "msgLev: should be int32");
-                    scmp->msg_lev = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                    scmp->msg_lev = val->Int32Value(context).FromJust();
                 } else if (keystr == "meth"){
                     V8CHECKBOOL(!val->IsInt32(), "meth: should be int32");
-                    scmp->meth = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                    scmp->meth = val->Int32Value(context).FromJust();
                 } else if (keystr == "pricing"){
                     V8CHECKBOOL(!val->IsInt32(), "pricing: should be int32");
-                    scmp->pricing = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                    scmp->pricing = val->Int32Value(context).FromJust();
                 } else if (keystr == "rTest"){
                     V8CHECKBOOL(!val->IsInt32(), "rTest: should be int32");
-                    scmp->r_test = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                    scmp->r_test = val->Int32Value(context).FromJust();
                 } else if (keystr == "tolBnd"){
                     V8CHECKBOOL(!val->IsNumber(), "tolBnd: should be a Number");
-                    scmp->tol_bnd = val->NumberValue(Nan::GetCurrentContext()).FromJust();
+                    scmp->tol_bnd = val->NumberValue(context).FromJust();
                 } else if (keystr == "tolDj"){
                     V8CHECKBOOL(!val->IsNumber(), "tolDj: should be a Number");
-                    scmp->tol_dj = val->NumberValue(Nan::GetCurrentContext()).FromJust();
+                    scmp->tol_dj = val->NumberValue(context).FromJust();
                 } else if (keystr == "tolPiv"){
                     V8CHECKBOOL(!val->IsNumber(), "tolPiv: should be a Number");
-                    scmp->tol_piv = val->NumberValue(Nan::GetCurrentContext()).FromJust();
+                    scmp->tol_piv = val->NumberValue(context).FromJust();
                 } else if (keystr == "objLl"){
                     V8CHECKBOOL(!val->IsNumber(), "objLl: should be a Number");
-                    scmp->obj_ll = val->NumberValue(Nan::GetCurrentContext()).FromJust();
+                    scmp->obj_ll = val->NumberValue(context).FromJust();
                 } else if (keystr == "objUl"){
                     V8CHECKBOOL(!val->IsNumber(), "objUl: should be a Number");
-                    scmp->obj_ul = val->NumberValue(Nan::GetCurrentContext()).FromJust();
+                    scmp->obj_ul = val->NumberValue(context).FromJust();
                 } else if (keystr == "itLim"){
                     V8CHECKBOOL(!val->IsInt32(), "itLim: should be int32");
-                    scmp->it_lim = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                    scmp->it_lim = val->Int32Value(context).FromJust();
                 } else if (keystr == "tmLim"){
                     V8CHECKBOOL(!val->IsInt32(), "tmLim: should be int32");
-                    scmp->tm_lim = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                    scmp->tm_lim = val->Int32Value(context).FromJust();
                 } else if (keystr == "outFrq"){
                     V8CHECKBOOL(!val->IsInt32(), "outFrq: should be int32");
-                    scmp->out_frq = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                    scmp->out_frq = val->Int32Value(context).FromJust();
                 } else if (keystr == "outDly"){
                     V8CHECKBOOL(!val->IsInt32(), "outDly: should be int32");
-                    scmp->out_dly = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                    scmp->out_dly = val->Int32Value(context).FromJust();
                 } else if (keystr == "presolve"){
                     V8CHECKBOOL(!val->IsInt32(), "presolve: should be int32");
-                    scmp->presolve = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                    scmp->presolve = val->Int32Value(context).FromJust();
                 } else {
                     std::string error("Unknow field: ");
                     error += keystr;
@@ -247,15 +247,15 @@ namespace NodeGLPK {
             double* par = new double[ar->Length()];
             Local<Context> context = Nan::GetCurrentContext();
             
-            for (size_t i = 0; i < ia->Length(); i++) pia[i] = ia->Get(context, i).ToLocalChecked()->Int32Value(Nan::GetCurrentContext()).FromJust();
-            for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(context, i).ToLocalChecked()->Int32Value(Nan::GetCurrentContext()).FromJust();
-            for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(context, i).ToLocalChecked()->NumberValue(Nan::GetCurrentContext()).FromJust();
+            for (size_t i = 0; i < ia->Length(); i++) pia[i] = ia->Get(context, i).ToLocalChecked()->Int32Value(context).FromJust();
+            for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(context, i).ToLocalChecked()->Int32Value(context).FromJust();
+            for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(context, i).ToLocalChecked()->NumberValue(context).FromJust();
             
             Problem* lp = ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            GLP_CATCH(glp_load_matrix(lp->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), pia, pja, par);)
+            GLP_CATCH(glp_load_matrix(lp->handle, info[0]->Int32Value(context).FromJust(), pia, pja, par);)
             
             delete[] pia;
             delete[] pja;
@@ -389,10 +389,10 @@ namespace NodeGLPK {
                 std::string keystr = std::string(V8TOCSTRING(key));
                 if (keystr == "msgLev"){
                     V8CHECKBOOL(!val->IsInt32(), "msgLev: should be int32");
-                    iptcp->msg_lev = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                    iptcp->msg_lev = val->Int32Value(context).FromJust();
                 } else if (keystr == "ordAlg"){
                     V8CHECKBOOL(!val->IsInt32(), "ordAlg: should be int32");
-                    iptcp->ord_alg = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                    iptcp->ord_alg = val->Int32Value(context).FromJust();
                 } else {
                     std::string error("Unknow field: ");
                     error += keystr;
@@ -472,10 +472,10 @@ namespace NodeGLPK {
                     std::string keystr = std::string(V8TOCSTRING(key));
                     if (keystr == "blank"){
                         V8CHECKBOOL(!val->IsInt32(), "blank: should be int32");
-                        mpscp->blank = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        mpscp->blank = val->Int32Value(context).FromJust();
                     } else if (keystr == "tolMps"){
                         V8CHECKBOOL(!val->IsNumber(), "tolMps: should be number");
-                        mpscp->tol_mps = val->NumberValue(Nan::GetCurrentContext()).FromJust();
+                        mpscp->tol_mps = val->NumberValue(context).FromJust();
                     } else if (keystr == "objName"){
                         V8CHECKBOOL(!val->IsString(), "objName: should be a string");
                         std::string objname = std::string(V8TOCSTRING(val));
@@ -660,67 +660,67 @@ namespace NodeGLPK {
                     std::string keystr = std::string(V8TOCSTRING(key));
                     if (keystr == "msgLev"){
                         V8CHECKBOOL(!val->IsInt32(), "msgLev: should be int32");
-                        iocp->msg_lev = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->msg_lev = val->Int32Value(context).FromJust();
                     } else if (keystr == "brTech"){
                         V8CHECKBOOL(!val->IsInt32(), "brTech: should be int32");
-                        iocp->br_tech = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->br_tech = val->Int32Value(context).FromJust();
                     } else if (keystr == "btTech"){
                         V8CHECKBOOL(!val->IsInt32(), "btTech: should be int32");
-                        iocp->bt_tech = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->bt_tech = val->Int32Value(context).FromJust();
                     } else if (keystr == "tolInt"){
                         V8CHECKBOOL(!val->IsNumber(), "tolInt: should be number");
-                        iocp->tol_int = val->NumberValue(Nan::GetCurrentContext()).FromJust();
+                        iocp->tol_int = val->NumberValue(context).FromJust();
                     } else if (keystr == "tolObj"){
                         V8CHECKBOOL(!val->IsNumber(), "tolObj: should be number");
-                        iocp->tol_obj = val->NumberValue(Nan::GetCurrentContext()).FromJust();
+                        iocp->tol_obj = val->NumberValue(context).FromJust();
                     } else if (keystr == "tmLim"){
                         V8CHECKBOOL(!val->IsInt32(), "tmLim: should be int32");
-                        iocp->tm_lim = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->tm_lim = val->Int32Value(context).FromJust();
                     } else if (keystr == "outFrq"){
                         V8CHECKBOOL(!val->IsInt32(), "outFrq: should be int32");
-                        iocp->out_frq = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->out_frq = val->Int32Value(context).FromJust();
                     } else if (keystr == "outDly"){
                         V8CHECKBOOL(!val->IsInt32(), "outDly: should be int32");
-                        iocp->out_dly = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->out_dly = val->Int32Value(context).FromJust();
                     } else if (keystr == "ppTech"){
                         V8CHECKBOOL(!val->IsInt32(), "ppTech: should be int32");
-                        iocp->pp_tech = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->pp_tech = val->Int32Value(context).FromJust();
                     } else if (keystr == "mipGap"){
                         V8CHECKBOOL(!val->IsNumber(), "mipGap: should be number");
-                        iocp->mip_gap = val->NumberValue(Nan::GetCurrentContext()).FromJust();
+                        iocp->mip_gap = val->NumberValue(context).FromJust();
                     } else if (keystr == "mirCuts"){
                         V8CHECKBOOL(!val->IsInt32(), "mirCuts: should be int32");
-                        iocp->mir_cuts = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->mir_cuts = val->Int32Value(context).FromJust();
                     } else if (keystr == "gmiCuts"){
                         V8CHECKBOOL(!val->IsInt32(), "gmiCuts: should be int32");
-                        iocp->gmi_cuts = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->gmi_cuts = val->Int32Value(context).FromJust();
                     } else if (keystr == "covCuts"){
                         V8CHECKBOOL(!val->IsInt32(), "covCuts: should be int32");
-                        iocp->cov_cuts = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->cov_cuts = val->Int32Value(context).FromJust();
                     } else if (keystr == "clqCuts"){
                         V8CHECKBOOL(!val->IsInt32(), "clqCuts: should be int32");
-                        iocp->clq_cuts = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->clq_cuts = val->Int32Value(context).FromJust();
                     } else if (keystr == "presolve"){
                         V8CHECKBOOL(!val->IsInt32(), "presolve: should be int32");
-                        iocp->presolve = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->presolve = val->Int32Value(context).FromJust();
                     } else if (keystr == "binarize"){
                         V8CHECKBOOL(!val->IsInt32(), "binarize: should be int32");
-                        iocp->binarize = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->binarize = val->Int32Value(context).FromJust();
                     } else if (keystr == "fpHeur"){
                         V8CHECKBOOL(!val->IsInt32(), "fpHeur: should be int32");
-                        iocp->fp_heur = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->fp_heur = val->Int32Value(context).FromJust();
                     } else if (keystr == "psHeur"){
                         V8CHECKBOOL(!val->IsInt32(), "psHeur: should be int32");
-                        iocp->ps_heur = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->ps_heur = val->Int32Value(context).FromJust();
                     } else if (keystr == "psTmLim"){
                         V8CHECKBOOL(!val->IsInt32(), "psTmLim: should be int32");
-                        iocp->ps_tm_lim = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->ps_tm_lim = val->Int32Value(context).FromJust();
                     } else if (keystr == "useSol"){
                         V8CHECKBOOL(!val->IsInt32(), "useSol: should be int32");
-                        iocp->use_sol = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->use_sol = val->Int32Value(context).FromJust();
                     } else if (keystr == "alien"){
                         V8CHECKBOOL(!val->IsInt32(), "alien: should be int32");
-                        iocp->alien = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->alien = val->Int32Value(context).FromJust();
                     } else if (keystr == "saveSol"){
                         V8CHECKBOOL(!val->IsString(), "saveSol: should be a string");
                         std::string solfile = std::string(V8TOCSTRING(val));
@@ -732,7 +732,7 @@ namespace NodeGLPK {
                         iocp->cb_info = new Nan::Callback(Local<Function>::Cast(val));
                     } else if (keystr == "cbReasons"){
                         V8CHECKBOOL(!val->IsInt32(), "cbReason: should be int32");
-                        iocp->cb_reasons = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        iocp->cb_reasons = val->Int32Value(context).FromJust();
                     } else {
                         std::string error("Unknow field: ");
                         error += keystr;
@@ -992,12 +992,12 @@ namespace NodeGLPK {
                     if (count > 1) {
                         plist = new int[count];
 
-                        for (size_t i = 0; i < count; i++) plist[i] = list->Get(context, i).ToLocalChecked()->Int32Value(Nan::GetCurrentContext()).FromJust();
+                        for (size_t i = 0; i < count; i++) plist[i] = list->Get(context, i).ToLocalChecked()->Int32Value(context).FromJust();
                         count--;
                     }
                 }
                       
-                ret = glp_print_ranges(lp->handle, count, plist, info[1]->Int32Value(Nan::GetCurrentContext()).FromJust(), V8TOCSTRING(info[2]));
+                ret = glp_print_ranges(lp->handle, count, plist, info[1]->Int32Value(context).FromJust(), V8TOCSTRING(info[2]));
                       
             )
             if (plist) delete[] plist;
@@ -1059,9 +1059,9 @@ namespace NodeGLPK {
             
             Nan::Callback *callback = new Nan::Callback(info[3].As<Function>());
             Local<Context> context = Nan::GetCurrentContext();
-            PrintRangesWorker *worker = new PrintRangesWorker(callback, lp, len, info[1]->Int32Value(Nan::GetCurrentContext()).FromJust(), V8TOCSTRING(info[2]));
+            PrintRangesWorker *worker = new PrintRangesWorker(callback, lp, len, info[1]->Int32Value(context).FromJust(), V8TOCSTRING(info[2]));
             if (len > 0) {
-                for (size_t i = 0; i < len; i++) worker->list[i] = list->Get(context, i).ToLocalChecked()->Int32Value(Nan::GetCurrentContext()).FromJust();
+                for (size_t i = 0; i < len; i++) worker->list[i] = list->Get(context, i).ToLocalChecked()->Int32Value(context).FromJust();
                 worker->len--;
             }
             
@@ -1112,25 +1112,25 @@ namespace NodeGLPK {
                               std::string keystr = std::string(V8TOCSTRING(key));
                               if (keystr == "type"){
                                   V8CHECK(!val->IsInt32(), "type: should be int32");
-                                  bfcp.type = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                                  bfcp.type = val->Int32Value(context).FromJust();
                               } else if (keystr == "pivTol"){
                                   V8CHECK(!val->IsNumber(), "pivTol: should be number");
-                                  bfcp.piv_tol = val->NumberValue(Nan::GetCurrentContext()).FromJust();
+                                  bfcp.piv_tol = val->NumberValue(context).FromJust();
                               } else if (keystr == "pivLim"){
                                   V8CHECK(!val->IsInt32(), "pivLim: should be int32");
-                                  bfcp.piv_lim = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                                  bfcp.piv_lim = val->Int32Value(context).FromJust();
                               } else if (keystr == "suhl"){
                                   V8CHECK(!val->IsInt32(), "suhl: should be int32");
-                                  bfcp.suhl = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                                  bfcp.suhl = val->Int32Value(context).FromJust();
                               } else if (keystr == "epsTol"){
                                   V8CHECK(!val->IsNumber(), "epsTol: should be number");
-                                  bfcp.eps_tol = val->NumberValue(Nan::GetCurrentContext()).FromJust();
+                                  bfcp.eps_tol = val->NumberValue(context).FromJust();
                               } else if (keystr == "nfsMax"){
                                   V8CHECK(!val->IsInt32(), "nfsMax: should be int32");
-                                  bfcp.nfs_max = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                                  bfcp.nfs_max = val->Int32Value(context).FromJust();
                               } else if (keystr == "nrsMax"){
                                   V8CHECK(!val->IsInt32(), "nrsMax: should be int32");
-                                  bfcp.nrs_max = val->Int32Value(Nan::GetCurrentContext()).FromJust();
+                                  bfcp.nrs_max = val->Int32Value(context).FromJust();
                               } else {
                                   std::string error("Unknow field: ");
                                   error += keystr;

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -13,7 +13,7 @@ namespace NodeGLPK {
     
     class Problem : public node::ObjectWrap {
     public:
-        static void Init(Handle<Object> exports){
+        static void Init(Local<Object> exports){
             // Prepare constructor template
             Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
             tpl->SetClassName(Nan::New<String>("Problem").ToLocalChecked());

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -151,7 +151,8 @@ namespace NodeGLPK {
             Nan::SetPrototypeMethod(tpl, "warmUp", WarmUp);
             
             constructor.Reset(tpl);
-            exports->Set(Nan::New<String>("Problem").ToLocalChecked(), tpl->GetFunction());
+
+            exports->Set(Nan::New<String>("Problem").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
         }
         
         static bool SmcpInit(glp_smcp* scmp, Local<Value> value){

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -158,7 +158,7 @@ namespace NodeGLPK {
         static bool SmcpInit(glp_smcp* scmp, Local<Value> value){
             if (!value->IsObject()) return false;
             Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
-            Local<Array> props = obj->GetPropertyNames();
+            Local<Array> props = Nan::GetPropertyNames(obj).ToLocalChecked();
             for(uint32_t i = 0; i < props->Length(); i++){
                 Local<Value> key = props->Get(i);
                 Local<Value> val = obj->Get(key);
@@ -379,7 +379,7 @@ namespace NodeGLPK {
         static bool IptcpInit(glp_iptcp* iptcp, Local<Value> value){
             if (!value->IsObject()) return true;
             Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
-            Local<Array> props = obj->GetPropertyNames();
+            Local<Array> props = Nan::GetPropertyNames(obj).ToLocalChecked();
             for(uint32_t i = 0; i < props->Length(); i++){
                 Local<Value> key = props->Get(i);
                 Local<Value> val = obj->Get(key);
@@ -461,7 +461,7 @@ namespace NodeGLPK {
         static bool MpscpInit(glp_mpscp *mpscp, Local<Value> value){
             if (value->IsObject()){
                 Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
-                Local<Array> props = obj->GetPropertyNames();
+                Local<Array> props = Nan::GetPropertyNames(obj).ToLocalChecked();
                 for(uint32_t i = 0; i < props->Length(); i++){
                     Local<Value> key = props->Get(i);
                     Local<Value> val = obj->Get(key);
@@ -648,7 +648,7 @@ namespace NodeGLPK {
         static bool IocpInit(glp_iocp *iocp, Local<Value> value){
             if (value->IsObject()){
                 Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
-                Local<Array> props = obj->GetPropertyNames();
+                Local<Array> props = Nan::GetPropertyNames(obj).ToLocalChecked();
                 for(uint32_t i = 0; i < props->Length(); i++){
                     Local<Value> key = props->Get(i);
                     Local<Value> val = obj->Get(key);
@@ -1096,7 +1096,7 @@ namespace NodeGLPK {
                       
                       if (info[0]->IsObject()){
                           Local<Object> obj = Nan::To<Object>(info[0]).ToLocalChecked();
-                          Local<Array> props = obj->GetPropertyNames();
+                          Local<Array> props = Nan::GetPropertyNames(obj).ToLocalChecked();
                           for(uint32_t i = 0; i < props->Length(); i++){
                               Local<Value> key = props->Get(i);
                               Local<Value> val = obj->Get(key);

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -157,7 +157,7 @@ namespace NodeGLPK {
         
         static bool SmcpInit(glp_smcp* scmp, Local<Value> value){
             if (!value->IsObject()) return false;
-            Local<Object> obj = value->ToObject();
+            Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
             Local<Array> props = obj->GetPropertyNames();
             for(uint32_t i = 0; i < props->Length(); i++){
                 Local<Value> key = props->Get(i);
@@ -378,7 +378,7 @@ namespace NodeGLPK {
         
         static bool IptcpInit(glp_iptcp* iptcp, Local<Value> value){
             if (!value->IsObject()) return true;
-            Local<Object> obj = value->ToObject();
+            Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
             Local<Array> props = obj->GetPropertyNames();
             for(uint32_t i = 0; i < props->Length(); i++){
                 Local<Value> key = props->Get(i);
@@ -460,7 +460,7 @@ namespace NodeGLPK {
         
         static bool MpscpInit(glp_mpscp *mpscp, Local<Value> value){
             if (value->IsObject()){
-                Local<Object> obj = value->ToObject();
+                Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
                 Local<Array> props = obj->GetPropertyNames();
                 for(uint32_t i = 0; i < props->Length(); i++){
                     Local<Value> key = props->Get(i);
@@ -639,7 +639,7 @@ namespace NodeGLPK {
             Local<Value> t = Tree::Instantiate(T);
             Local<Value> argv[argc] = {Nan::New<Value>(t)};
             cb->Call(argc, argv);
-            Tree* host = ObjectWrap::Unwrap<Tree>(t->ToObject());
+            Tree* host = ObjectWrap::Unwrap<Tree>(Nan::To<Object>(t).ToLocalChecked());
             host->thread = true;
             host->handle = NULL;
         };
@@ -647,7 +647,7 @@ namespace NodeGLPK {
         
         static bool IocpInit(glp_iocp *iocp, Local<Value> value){
             if (value->IsObject()){
-                Local<Object> obj = value->ToObject();
+                Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
                 Local<Array> props = obj->GetPropertyNames();
                 for(uint32_t i = 0; i < props->Length(); i++){
                     Local<Value> key = props->Get(i);
@@ -1095,7 +1095,7 @@ namespace NodeGLPK {
                       glp_get_bfcp(lp->handle, &bfcp);
                       
                       if (info[0]->IsObject()){
-                          Local<Object> obj = info[0]->ToObject();
+                          Local<Object> obj = Nan::To<Object>(info[0]).ToLocalChecked();
                           Local<Array> props = obj->GetPropertyNames();
                           for(uint32_t i = 0; i < props->Length(); i++){
                               Local<Value> key = props->Get(i);

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -152,7 +152,7 @@ namespace NodeGLPK {
             
             constructor.Reset(tpl);
 
-            exports->Set(Nan::New<String>("Problem").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
+            exports->Set(Nan::GetCurrentContext(), Nan::New<String>("Problem").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked()).Check();
         }
         
         static bool SmcpInit(glp_smcp* scmp, Local<Value> value){

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -164,16 +164,16 @@ namespace NodeGLPK {
                 std::string keystr = std::string(V8TOCSTRING(key));
                 if (keystr == "msgLev"){
                     V8CHECKBOOL(!val->IsInt32(), "msgLev: should be int32");
-                    scmp->msg_lev = val->Int32Value();
+                    scmp->msg_lev = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                 } else if (keystr == "meth"){
                     V8CHECKBOOL(!val->IsInt32(), "meth: should be int32");
-                    scmp->meth = val->Int32Value();
+                    scmp->meth = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                 } else if (keystr == "pricing"){
                     V8CHECKBOOL(!val->IsInt32(), "pricing: should be int32");
-                    scmp->pricing = val->Int32Value();
+                    scmp->pricing = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                 } else if (keystr == "rTest"){
                     V8CHECKBOOL(!val->IsInt32(), "rTest: should be int32");
-                    scmp->r_test = val->Int32Value();
+                    scmp->r_test = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                 } else if (keystr == "tolBnd"){
                     V8CHECKBOOL(!val->IsNumber(), "tolBnd: should be a Number");
                     scmp->tol_bnd = val->NumberValue();
@@ -191,19 +191,19 @@ namespace NodeGLPK {
                     scmp->obj_ul = val->NumberValue();
                 } else if (keystr == "itLim"){
                     V8CHECKBOOL(!val->IsInt32(), "itLim: should be int32");
-                    scmp->it_lim = val->Int32Value();
+                    scmp->it_lim = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                 } else if (keystr == "tmLim"){
                     V8CHECKBOOL(!val->IsInt32(), "tmLim: should be int32");
-                    scmp->tm_lim = val->Int32Value();
+                    scmp->tm_lim = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                 } else if (keystr == "outFrq"){
                     V8CHECKBOOL(!val->IsInt32(), "outFrq: should be int32");
-                    scmp->out_frq = val->Int32Value();
+                    scmp->out_frq = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                 } else if (keystr == "outDly"){
                     V8CHECKBOOL(!val->IsInt32(), "outDly: should be int32");
-                    scmp->out_dly = val->Int32Value();
+                    scmp->out_dly = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                 } else if (keystr == "presolve"){
                     V8CHECKBOOL(!val->IsInt32(), "presolve: should be int32");
-                    scmp->presolve = val->Int32Value();
+                    scmp->presolve = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                 } else {
                     std::string error("Unknow field: ");
                     error += keystr;
@@ -244,15 +244,15 @@ namespace NodeGLPK {
             int* pja = new int[ja->Length()];
             double* par = new double[ar->Length()];
             
-            for (size_t i = 0; i < ia->Length(); i++) pia[i] = ia->Get(i)->Int32Value();
-            for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(i)->Int32Value();
+            for (size_t i = 0; i < ia->Length(); i++) pia[i] = ia->Get(i)->Int32Value(Nan::GetCurrentContext()).FromJust();
+            for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(i)->Int32Value(Nan::GetCurrentContext()).FromJust();
             for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(i)->NumberValue();
             
             Problem* lp = ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            GLP_CATCH(glp_load_matrix(lp->handle, info[0]->Int32Value(), pia, pja, par);)
+            GLP_CATCH(glp_load_matrix(lp->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), pia, pja, par);)
             
             delete[] pia;
             delete[] pja;
@@ -385,10 +385,10 @@ namespace NodeGLPK {
                 std::string keystr = std::string(V8TOCSTRING(key));
                 if (keystr == "msgLev"){
                     V8CHECKBOOL(!val->IsInt32(), "msgLev: should be int32");
-                    iptcp->msg_lev = val->Int32Value();
+                    iptcp->msg_lev = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                 } else if (keystr == "ordAlg"){
                     V8CHECKBOOL(!val->IsInt32(), "ordAlg: should be int32");
-                    iptcp->ord_alg = val->Int32Value();
+                    iptcp->ord_alg = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                 } else {
                     std::string error("Unknow field: ");
                     error += keystr;
@@ -467,7 +467,7 @@ namespace NodeGLPK {
                     std::string keystr = std::string(V8TOCSTRING(key));
                     if (keystr == "blank"){
                         V8CHECKBOOL(!val->IsInt32(), "blank: should be int32");
-                        mpscp->blank = val->Int32Value();
+                        mpscp->blank = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "tolMps"){
                         V8CHECKBOOL(!val->IsNumber(), "tolMps: should be number");
                         mpscp->tol_mps = val->NumberValue();
@@ -500,7 +500,7 @@ namespace NodeGLPK {
                 V8CHECK(!lp->handle, "object deleted");
                 V8CHECK(lp->thread, "an async operation is inprogress");
                           
-                int ret = glp_read_mps(lp->handle, info[0]->Int32Value(), &mpscp, V8TOCSTRING(info[2]));
+                int ret = glp_read_mps(lp->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), &mpscp, V8TOCSTRING(info[2]));
                 if (mpscp.obj_name) delete[] mpscp.obj_name;
                 info.GetReturnValue().Set(ret);
             )
@@ -549,7 +549,7 @@ namespace NodeGLPK {
             V8CHECK(lp->thread, "an async operation is inprogress");
             
             Nan::Callback *callback = new Nan::Callback(info[3].As<Function>());
-            ReadMpsWorker *worker = new ReadMpsWorker(callback, lp, info[0]->Int32Value(), V8TOCSTRING(info[2]));
+            ReadMpsWorker *worker = new ReadMpsWorker(callback, lp, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), V8TOCSTRING(info[2]));
             if (!MpscpInit(&worker->mpscp, info[1])){
                 worker->Destroy();
                 return;
@@ -574,7 +574,7 @@ namespace NodeGLPK {
               V8CHECK(!lp->handle, "object deleted");
               V8CHECK(lp->thread, "an async operation is inprogress");
                           
-              info.GetReturnValue().Set(glp_write_mps(lp->handle, info[0]->Int32Value(), &mpscp, V8TOCSTRING(info[2])));
+              info.GetReturnValue().Set(glp_write_mps(lp->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), &mpscp, V8TOCSTRING(info[2])));
             )
         }
         
@@ -621,7 +621,7 @@ namespace NodeGLPK {
             V8CHECK(lp->thread, "an async operation is inprogress");
             
             Nan::Callback *callback = new Nan::Callback(info[3].As<Function>());
-            WriteMpsWorker *worker = new WriteMpsWorker(callback, lp, info[0]->Int32Value(), V8TOCSTRING(info[2]));
+            WriteMpsWorker *worker = new WriteMpsWorker(callback, lp, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), V8TOCSTRING(info[2]));
             if (!MpscpInit(&worker->mpscp, info[1])){
                 worker->Destroy();
                 return;
@@ -654,13 +654,13 @@ namespace NodeGLPK {
                     std::string keystr = std::string(V8TOCSTRING(key));
                     if (keystr == "msgLev"){
                         V8CHECKBOOL(!val->IsInt32(), "msgLev: should be int32");
-                        iocp->msg_lev = val->Int32Value();
+                        iocp->msg_lev = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "brTech"){
                         V8CHECKBOOL(!val->IsInt32(), "brTech: should be int32");
-                        iocp->br_tech = val->Int32Value();
+                        iocp->br_tech = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "btTech"){
                         V8CHECKBOOL(!val->IsInt32(), "btTech: should be int32");
-                        iocp->bt_tech = val->Int32Value();
+                        iocp->bt_tech = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "tolInt"){
                         V8CHECKBOOL(!val->IsNumber(), "tolInt: should be number");
                         iocp->tol_int = val->NumberValue();
@@ -669,52 +669,52 @@ namespace NodeGLPK {
                         iocp->tol_obj = val->NumberValue();
                     } else if (keystr == "tmLim"){
                         V8CHECKBOOL(!val->IsInt32(), "tmLim: should be int32");
-                        iocp->tm_lim = val->Int32Value();
+                        iocp->tm_lim = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "outFrq"){
                         V8CHECKBOOL(!val->IsInt32(), "outFrq: should be int32");
-                        iocp->out_frq = val->Int32Value();
+                        iocp->out_frq = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "outDly"){
                         V8CHECKBOOL(!val->IsInt32(), "outDly: should be int32");
-                        iocp->out_dly = val->Int32Value();
+                        iocp->out_dly = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "ppTech"){
                         V8CHECKBOOL(!val->IsInt32(), "ppTech: should be int32");
-                        iocp->pp_tech = val->Int32Value();
+                        iocp->pp_tech = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "mipGap"){
                         V8CHECKBOOL(!val->IsNumber(), "mipGap: should be number");
                         iocp->mip_gap = val->NumberValue();
                     } else if (keystr == "mirCuts"){
                         V8CHECKBOOL(!val->IsInt32(), "mirCuts: should be int32");
-                        iocp->mir_cuts = val->Int32Value();
+                        iocp->mir_cuts = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "gmiCuts"){
                         V8CHECKBOOL(!val->IsInt32(), "gmiCuts: should be int32");
-                        iocp->gmi_cuts = val->Int32Value();
+                        iocp->gmi_cuts = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "covCuts"){
                         V8CHECKBOOL(!val->IsInt32(), "covCuts: should be int32");
-                        iocp->cov_cuts = val->Int32Value();
+                        iocp->cov_cuts = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "clqCuts"){
                         V8CHECKBOOL(!val->IsInt32(), "clqCuts: should be int32");
-                        iocp->clq_cuts = val->Int32Value();
+                        iocp->clq_cuts = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "presolve"){
                         V8CHECKBOOL(!val->IsInt32(), "presolve: should be int32");
-                        iocp->presolve = val->Int32Value();
+                        iocp->presolve = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "binarize"){
                         V8CHECKBOOL(!val->IsInt32(), "binarize: should be int32");
-                        iocp->binarize = val->Int32Value();
+                        iocp->binarize = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "fpHeur"){
                         V8CHECKBOOL(!val->IsInt32(), "fpHeur: should be int32");
-                        iocp->fp_heur = val->Int32Value();
+                        iocp->fp_heur = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "psHeur"){
                         V8CHECKBOOL(!val->IsInt32(), "psHeur: should be int32");
-                        iocp->ps_heur = val->Int32Value();
+                        iocp->ps_heur = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "psTmLim"){
                         V8CHECKBOOL(!val->IsInt32(), "psTmLim: should be int32");
-                        iocp->ps_tm_lim = val->Int32Value();
+                        iocp->ps_tm_lim = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "useSol"){
                         V8CHECKBOOL(!val->IsInt32(), "useSol: should be int32");
-                        iocp->use_sol = val->Int32Value();
+                        iocp->use_sol = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "alien"){
                         V8CHECKBOOL(!val->IsInt32(), "alien: should be int32");
-                        iocp->alien = val->Int32Value();
+                        iocp->alien = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "saveSol"){
                         V8CHECKBOOL(!val->IsString(), "saveSol: should be a string");
                         std::string solfile = std::string(V8TOCSTRING(val));
@@ -726,7 +726,7 @@ namespace NodeGLPK {
                         iocp->cb_info = new Nan::Callback(Local<Function>::Cast(val));
                     } else if (keystr == "cbReasons"){
                         V8CHECKBOOL(!val->IsInt32(), "cbReason: should be int32");
-                        iocp->cb_reasons = val->Int32Value();
+                        iocp->cb_reasons = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else {
                         std::string error("Unknow field: ");
                         error += keystr;
@@ -952,7 +952,7 @@ namespace NodeGLPK {
             
             double ae_max, re_max;
             int ae_ind, re_ind;
-            GLP_CATCH_RET(glp_check_kkt(lp->handle, info[0]->Int32Value(), info[1]->Int32Value(), &ae_max, &ae_ind, &re_max, &re_ind);)
+            GLP_CATCH_RET(glp_check_kkt(lp->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), info[1]->Int32Value(Nan::GetCurrentContext()).FromJust(), &ae_max, &ae_ind, &re_max, &re_ind);)
             
             Nan::Callback* cb = new Nan::Callback(Local<Function>::Cast(info[2]));
             const unsigned argc = 4;
@@ -984,12 +984,12 @@ namespace NodeGLPK {
                     count = list->Length();
                     if (count > 1) {
                         plist = new int[count];
-                        for (size_t i = 0; i < count; i++) plist[i] = list->Get(i)->Int32Value();
+                        for (size_t i = 0; i < count; i++) plist[i] = list->Get(i)->Int32Value(Nan::GetCurrentContext()).FromJust();
                         count--;
                     }
                 }
                       
-                ret = glp_print_ranges(lp->handle, count, plist, info[1]->Int32Value(), V8TOCSTRING(info[2]));
+                ret = glp_print_ranges(lp->handle, count, plist, info[1]->Int32Value(Nan::GetCurrentContext()).FromJust(), V8TOCSTRING(info[2]));
                       
             )
             if (plist) delete[] plist;
@@ -1050,9 +1050,9 @@ namespace NodeGLPK {
             }
             
             Nan::Callback *callback = new Nan::Callback(info[3].As<Function>());
-            PrintRangesWorker *worker = new PrintRangesWorker(callback, lp, len, info[1]->Int32Value(), V8TOCSTRING(info[2]));
+            PrintRangesWorker *worker = new PrintRangesWorker(callback, lp, len, info[1]->Int32Value(Nan::GetCurrentContext()).FromJust(), V8TOCSTRING(info[2]));
             if (len > 0) {
-                for (size_t i = 0; i < len; i++) worker->list[i] = list->Get(i)->Int32Value();
+                for (size_t i = 0; i < len; i++) worker->list[i] = list->Get(i)->Int32Value(Nan::GetCurrentContext()).FromJust();
                 worker->len--;
             }
             
@@ -1102,25 +1102,25 @@ namespace NodeGLPK {
                               std::string keystr = std::string(V8TOCSTRING(key));
                               if (keystr == "type"){
                                   V8CHECK(!val->IsInt32(), "type: should be int32");
-                                  bfcp.type = val->Int32Value();
+                                  bfcp.type = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                               } else if (keystr == "pivTol"){
                                   V8CHECK(!val->IsNumber(), "pivTol: should be number");
                                   bfcp.piv_tol = val->NumberValue();
                               } else if (keystr == "pivLim"){
                                   V8CHECK(!val->IsInt32(), "pivLim: should be int32");
-                                  bfcp.piv_lim = val->Int32Value();
+                                  bfcp.piv_lim = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                               } else if (keystr == "suhl"){
                                   V8CHECK(!val->IsInt32(), "suhl: should be int32");
-                                  bfcp.suhl = val->Int32Value();
+                                  bfcp.suhl = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                               } else if (keystr == "epsTol"){
                                   V8CHECK(!val->IsNumber(), "epsTol: should be number");
                                   bfcp.eps_tol = val->NumberValue();
                               } else if (keystr == "nfsMax"){
                                   V8CHECK(!val->IsInt32(), "nfsMax: should be int32");
-                                  bfcp.nfs_max = val->Int32Value();
+                                  bfcp.nfs_max = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                               } else if (keystr == "nrsMax"){
                                   V8CHECK(!val->IsInt32(), "nrsMax: should be int32");
-                                  bfcp.nrs_max = val->Int32Value();
+                                  bfcp.nrs_max = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                               } else {
                                   std::string error("Unknow field: ");
                                   error += keystr;
@@ -1163,7 +1163,7 @@ namespace NodeGLPK {
             V8CHECK(lp->thread, "an async operation is inprogress");
             
             Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
-            ScaleWorker *worker = new ScaleWorker(callback, lp, info[0]->Int32Value());
+            ScaleWorker *worker = new ScaleWorker(callback, lp, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust());
             lp->thread = true;
             Nan::AsyncQueueWorker(worker);
         }

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -530,7 +530,7 @@ namespace NodeGLPK {
             }
             void HandleOKCallback() {
                 Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
-                callback->Call(2, info);
+                callback->Call(2, info, async_resource);
             }
             
         public:
@@ -602,7 +602,7 @@ namespace NodeGLPK {
             }
             void HandleOKCallback() {
                 Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
-                callback->Call(2, info);
+                callback->Call(2, info, async_resource);
             }
             
         public:
@@ -807,7 +807,7 @@ namespace NodeGLPK {
             
             void HandleOKCallback(){
                 Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ctx.ret)};
-                callback->Call(2, info);
+                callback->Call(2, info, async_resource);
             }
             
             void Destroy() {
@@ -868,7 +868,7 @@ namespace NodeGLPK {
             }
             void HandleOKCallback() {
                 Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
-                callback->Call(2, info);
+                callback->Call(2, info, async_resource);
             }
             
         public:
@@ -921,7 +921,7 @@ namespace NodeGLPK {
             }
             void HandleOKCallback() {
                 Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
-                callback->Call(2, info);
+                callback->Call(2, info, async_resource);
             }
         public:
             int ret;
@@ -1013,7 +1013,7 @@ namespace NodeGLPK {
             
             void HandleOKCallback() {
                 Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
-                callback->Call(2, info);
+                callback->Call(2, info, async_resource);
             }
             void WorkComplete() {
                 lp->thread = false;
@@ -1188,7 +1188,7 @@ namespace NodeGLPK {
             }
             void HandleOKCallback() {
                 Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
-                callback->Call(2, info);
+                callback->Call(2, info, async_resource);
             }
         public:
             Problem *lp;

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -176,19 +176,19 @@ namespace NodeGLPK {
                     scmp->r_test = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                 } else if (keystr == "tolBnd"){
                     V8CHECKBOOL(!val->IsNumber(), "tolBnd: should be a Number");
-                    scmp->tol_bnd = val->NumberValue();
+                    scmp->tol_bnd = val->NumberValue(Nan::GetCurrentContext()).FromJust();
                 } else if (keystr == "tolDj"){
                     V8CHECKBOOL(!val->IsNumber(), "tolDj: should be a Number");
-                    scmp->tol_dj = val->NumberValue();
+                    scmp->tol_dj = val->NumberValue(Nan::GetCurrentContext()).FromJust();
                 } else if (keystr == "tolPiv"){
                     V8CHECKBOOL(!val->IsNumber(), "tolPiv: should be a Number");
-                    scmp->tol_piv = val->NumberValue();
+                    scmp->tol_piv = val->NumberValue(Nan::GetCurrentContext()).FromJust();
                 } else if (keystr == "objLl"){
                     V8CHECKBOOL(!val->IsNumber(), "objLl: should be a Number");
-                    scmp->obj_ll = val->NumberValue();
+                    scmp->obj_ll = val->NumberValue(Nan::GetCurrentContext()).FromJust();
                 } else if (keystr == "objUl"){
                     V8CHECKBOOL(!val->IsNumber(), "objUl: should be a Number");
-                    scmp->obj_ul = val->NumberValue();
+                    scmp->obj_ul = val->NumberValue(Nan::GetCurrentContext()).FromJust();
                 } else if (keystr == "itLim"){
                     V8CHECKBOOL(!val->IsInt32(), "itLim: should be int32");
                     scmp->it_lim = val->Int32Value(Nan::GetCurrentContext()).FromJust();
@@ -246,7 +246,7 @@ namespace NodeGLPK {
             
             for (size_t i = 0; i < ia->Length(); i++) pia[i] = ia->Get(i)->Int32Value(Nan::GetCurrentContext()).FromJust();
             for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(i)->Int32Value(Nan::GetCurrentContext()).FromJust();
-            for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(i)->NumberValue();
+            for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(i)->NumberValue(Nan::GetCurrentContext()).FromJust();
             
             Problem* lp = ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
@@ -470,7 +470,7 @@ namespace NodeGLPK {
                         mpscp->blank = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "tolMps"){
                         V8CHECKBOOL(!val->IsNumber(), "tolMps: should be number");
-                        mpscp->tol_mps = val->NumberValue();
+                        mpscp->tol_mps = val->NumberValue(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "objName"){
                         V8CHECKBOOL(!val->IsString(), "objName: should be a string");
                         std::string objname = std::string(V8TOCSTRING(val));
@@ -663,10 +663,10 @@ namespace NodeGLPK {
                         iocp->bt_tech = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "tolInt"){
                         V8CHECKBOOL(!val->IsNumber(), "tolInt: should be number");
-                        iocp->tol_int = val->NumberValue();
+                        iocp->tol_int = val->NumberValue(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "tolObj"){
                         V8CHECKBOOL(!val->IsNumber(), "tolObj: should be number");
-                        iocp->tol_obj = val->NumberValue();
+                        iocp->tol_obj = val->NumberValue(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "tmLim"){
                         V8CHECKBOOL(!val->IsInt32(), "tmLim: should be int32");
                         iocp->tm_lim = val->Int32Value(Nan::GetCurrentContext()).FromJust();
@@ -681,7 +681,7 @@ namespace NodeGLPK {
                         iocp->pp_tech = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "mipGap"){
                         V8CHECKBOOL(!val->IsNumber(), "mipGap: should be number");
-                        iocp->mip_gap = val->NumberValue();
+                        iocp->mip_gap = val->NumberValue(Nan::GetCurrentContext()).FromJust();
                     } else if (keystr == "mirCuts"){
                         V8CHECKBOOL(!val->IsInt32(), "mirCuts: should be int32");
                         iocp->mir_cuts = val->Int32Value(Nan::GetCurrentContext()).FromJust();
@@ -1105,7 +1105,7 @@ namespace NodeGLPK {
                                   bfcp.type = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                               } else if (keystr == "pivTol"){
                                   V8CHECK(!val->IsNumber(), "pivTol: should be number");
-                                  bfcp.piv_tol = val->NumberValue();
+                                  bfcp.piv_tol = val->NumberValue(Nan::GetCurrentContext()).FromJust();
                               } else if (keystr == "pivLim"){
                                   V8CHECK(!val->IsInt32(), "pivLim: should be int32");
                                   bfcp.piv_lim = val->Int32Value(Nan::GetCurrentContext()).FromJust();
@@ -1114,7 +1114,7 @@ namespace NodeGLPK {
                                   bfcp.suhl = val->Int32Value(Nan::GetCurrentContext()).FromJust();
                               } else if (keystr == "epsTol"){
                                   V8CHECK(!val->IsNumber(), "epsTol: should be number");
-                                  bfcp.eps_tol = val->NumberValue();
+                                  bfcp.eps_tol = val->NumberValue(Nan::GetCurrentContext()).FromJust();
                               } else if (keystr == "nfsMax"){
                                   V8CHECK(!val->IsInt32(), "nfsMax: should be int32");
                                   bfcp.nfs_max = val->Int32Value(Nan::GetCurrentContext()).FromJust();

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -159,9 +159,10 @@ namespace NodeGLPK {
             if (!value->IsObject()) return false;
             Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
             Local<Array> props = Nan::GetPropertyNames(obj).ToLocalChecked();
+            Local<Context> context = Nan::GetCurrentContext();
             for(uint32_t i = 0; i < props->Length(); i++){
-                Local<Value> key = props->Get(i);
-                Local<Value> val = obj->Get(key);
+                Local<Value> key = props->Get(context, i).ToLocalChecked();
+                Local<Value> val = obj->Get(context, key).ToLocalChecked();
                 std::string keystr = std::string(V8TOCSTRING(key));
                 if (keystr == "msgLev"){
                     V8CHECKBOOL(!val->IsInt32(), "msgLev: should be int32");
@@ -244,10 +245,11 @@ namespace NodeGLPK {
             int* pia = new int[ia->Length()];
             int* pja = new int[ja->Length()];
             double* par = new double[ar->Length()];
+            Local<Context> context = Nan::GetCurrentContext();
             
-            for (size_t i = 0; i < ia->Length(); i++) pia[i] = ia->Get(i)->Int32Value(Nan::GetCurrentContext()).FromJust();
-            for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(i)->Int32Value(Nan::GetCurrentContext()).FromJust();
-            for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(i)->NumberValue(Nan::GetCurrentContext()).FromJust();
+            for (size_t i = 0; i < ia->Length(); i++) pia[i] = ia->Get(context, i).ToLocalChecked()->Int32Value(Nan::GetCurrentContext()).FromJust();
+            for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(context, i).ToLocalChecked()->Int32Value(Nan::GetCurrentContext()).FromJust();
+            for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(context, i).ToLocalChecked()->NumberValue(Nan::GetCurrentContext()).FromJust();
             
             Problem* lp = ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
@@ -380,9 +382,10 @@ namespace NodeGLPK {
             if (!value->IsObject()) return true;
             Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
             Local<Array> props = Nan::GetPropertyNames(obj).ToLocalChecked();
+            Local<Context> context = Nan::GetCurrentContext();
             for(uint32_t i = 0; i < props->Length(); i++){
-                Local<Value> key = props->Get(i);
-                Local<Value> val = obj->Get(key);
+                Local<Value> key = props->Get(context, i).ToLocalChecked();
+                Local<Value> val = obj->Get(context, key).ToLocalChecked();
                 std::string keystr = std::string(V8TOCSTRING(key));
                 if (keystr == "msgLev"){
                     V8CHECKBOOL(!val->IsInt32(), "msgLev: should be int32");
@@ -462,9 +465,10 @@ namespace NodeGLPK {
             if (value->IsObject()){
                 Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
                 Local<Array> props = Nan::GetPropertyNames(obj).ToLocalChecked();
+                Local<Context> context = Nan::GetCurrentContext();
                 for(uint32_t i = 0; i < props->Length(); i++){
-                    Local<Value> key = props->Get(i);
-                    Local<Value> val = obj->Get(key);
+                    Local<Value> key = props->Get(context, i).ToLocalChecked();
+                    Local<Value> val = obj->Get(context, key).ToLocalChecked();
                     std::string keystr = std::string(V8TOCSTRING(key));
                     if (keystr == "blank"){
                         V8CHECKBOOL(!val->IsInt32(), "blank: should be int32");
@@ -649,9 +653,10 @@ namespace NodeGLPK {
             if (value->IsObject()){
                 Local<Object> obj = Nan::To<Object>(value).ToLocalChecked();
                 Local<Array> props = Nan::GetPropertyNames(obj).ToLocalChecked();
+                Local<Context> context = Nan::GetCurrentContext();
                 for(uint32_t i = 0; i < props->Length(); i++){
-                    Local<Value> key = props->Get(i);
-                    Local<Value> val = obj->Get(key);
+                    Local<Value> key = props->Get(context, i).ToLocalChecked();
+                    Local<Value> val = obj->Get(context, key).ToLocalChecked();
                     std::string keystr = std::string(V8TOCSTRING(key));
                     if (keystr == "msgLev"){
                         V8CHECKBOOL(!val->IsInt32(), "msgLev: should be int32");
@@ -980,12 +985,14 @@ namespace NodeGLPK {
             int* plist = NULL;
             int ret = 0;
             GLP_CATCH(
+                Local<Context> context = Nan::GetCurrentContext();
                 if (info[0]->IsInt32Array()) {
                     Local<Int32Array> list = Local<Int32Array>::Cast(info[0]);
                     count = list->Length();
                     if (count > 1) {
                         plist = new int[count];
-                        for (size_t i = 0; i < count; i++) plist[i] = list->Get(i)->Int32Value(Nan::GetCurrentContext()).FromJust();
+
+                        for (size_t i = 0; i < count; i++) plist[i] = list->Get(context, i).ToLocalChecked()->Int32Value(Nan::GetCurrentContext()).FromJust();
                         count--;
                     }
                 }
@@ -1051,9 +1058,10 @@ namespace NodeGLPK {
             }
             
             Nan::Callback *callback = new Nan::Callback(info[3].As<Function>());
+            Local<Context> context = Nan::GetCurrentContext();
             PrintRangesWorker *worker = new PrintRangesWorker(callback, lp, len, info[1]->Int32Value(Nan::GetCurrentContext()).FromJust(), V8TOCSTRING(info[2]));
             if (len > 0) {
-                for (size_t i = 0; i < len; i++) worker->list[i] = list->Get(i)->Int32Value(Nan::GetCurrentContext()).FromJust();
+                for (size_t i = 0; i < len; i++) worker->list[i] = list->Get(context, i).ToLocalChecked()->Int32Value(Nan::GetCurrentContext()).FromJust();
                 worker->len--;
             }
             
@@ -1097,9 +1105,10 @@ namespace NodeGLPK {
                       if (info[0]->IsObject()){
                           Local<Object> obj = Nan::To<Object>(info[0]).ToLocalChecked();
                           Local<Array> props = Nan::GetPropertyNames(obj).ToLocalChecked();
+                          Local<Context> context = Nan::GetCurrentContext();
                           for(uint32_t i = 0; i < props->Length(); i++){
-                              Local<Value> key = props->Get(i);
-                              Local<Value> val = obj->Get(key);
+                              Local<Value> key = props->Get(context, i).ToLocalChecked();
+                              Local<Value> val = obj->Get(context, key).ToLocalChecked();
                               std::string keystr = std::string(V8TOCSTRING(key));
                               if (keystr == "type"){
                                   V8CHECK(!val->IsInt32(), "type: should be int32");

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -44,7 +44,7 @@ namespace NodeGLPK {
         }
 
         static Local<Value> Instantiate(glp_tree* tree){
-            Local<Function> cons = Nan::New<FunctionTemplate>(constructor)->GetFunction();
+            Local<Function> cons = Nan::GetFunction(Nan::New<FunctionTemplate>(constructor)).ToLocalChecked();
             Local<Value> ret = Nan::NewInstance(cons).ToLocalChecked();
             Tree* host = ObjectWrap::Unwrap<Tree>(ret->ToObject());
             host->handle = tree;

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -141,12 +141,12 @@ namespace NodeGLPK {
             
             for (unsigned int i = 0; i < count; i++){
                 pind[i] = ind->Int32Value(Nan::GetCurrentContext()).FromJust();
-                pval[i] = val->NumberValue();
+                pval[i] = val->NumberValue(Nan::GetCurrentContext()).FromJust();
             }
             
             count--;
             GLP_CATCH(info.GetReturnValue().Set(glp_ios_add_row(tree->handle, V8TOCSTRING(info[0]), info[1]->Int32Value(Nan::GetCurrentContext()).FromJust(),
-                info[2]->Int32Value(Nan::GetCurrentContext()).FromJust(), count, pind, pval, info[5]->Int32Value(Nan::GetCurrentContext()).FromJust(), info[6]->NumberValue()));)
+                info[2]->Int32Value(Nan::GetCurrentContext()).FromJust(), count, pind, pval, info[5]->Int32Value(Nan::GetCurrentContext()).FromJust(), info[6]->NumberValue(Nan::GetCurrentContext()).FromJust()));)
             
             free(pind);
             free(pval);
@@ -176,7 +176,7 @@ namespace NodeGLPK {
             GLP_CATCH_RET(V8CHECK(count != (glp_get_num_cols(glp_ios_get_prob(tree->handle)) + 1), "Invalid arrays length");)
             
             double* px = (double*)malloc(count * sizeof(double));
-            for (int i = 0; i < count; i++) px[i] = x->NumberValue();
+            for (int i = 0; i < count; i++) px[i] = x->NumberValue(Nan::GetCurrentContext()).FromJust();
             GLP_CATCH(info.GetReturnValue().Set(glp_ios_heur_sol(tree->handle, px));)
             free(px);
         }

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -109,7 +109,7 @@ namespace NodeGLPK {
             V8CHECK(host->thread, "an async operation is inprogress");
             
             glp_attr attr;
-            GLP_CATCH_RET(glp_ios_row_attr(host->handle, info[0]->Int32Value(), &attr);)
+            GLP_CATCH_RET(glp_ios_row_attr(host->handle, info[0]->Int32Value(Nan::GetCurrentContext()).FromJust(), &attr);)
             
             Local<Object> ret = Nan::New<Object>();
             GLP_SET_FIELD_INT32(ret, "level", attr.level);
@@ -140,13 +140,13 @@ namespace NodeGLPK {
             double* pval = (double*)malloc(count * sizeof(double));
             
             for (unsigned int i = 0; i < count; i++){
-                pind[i] = ind->Int32Value();
+                pind[i] = ind->Int32Value(Nan::GetCurrentContext()).FromJust();
                 pval[i] = val->NumberValue();
             }
             
             count--;
-            GLP_CATCH(info.GetReturnValue().Set(glp_ios_add_row(tree->handle, V8TOCSTRING(info[0]), info[1]->Int32Value(),
-                info[2]->Int32Value(), count, pind, pval, info[5]->Int32Value(), info[6]->NumberValue()));)
+            GLP_CATCH(info.GetReturnValue().Set(glp_ios_add_row(tree->handle, V8TOCSTRING(info[0]), info[1]->Int32Value(Nan::GetCurrentContext()).FromJust(),
+                info[2]->Int32Value(Nan::GetCurrentContext()).FromJust(), count, pind, pval, info[5]->Int32Value(Nan::GetCurrentContext()).FromJust(), info[6]->NumberValue()));)
             
             free(pind);
             free(pval);

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -11,7 +11,7 @@ namespace NodeGLPK {
     
     class Tree : public node::ObjectWrap {
     public:
-        static void Init(Handle<Object> exports){
+        static void Init(Local<Object> exports){
             // Prepare constructor template
             Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
             tpl->SetClassName(Nan::New("Tree").ToLocalChecked());

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -46,7 +46,7 @@ namespace NodeGLPK {
         static Local<Value> Instantiate(glp_tree* tree){
             Local<Function> cons = Nan::GetFunction(Nan::New<FunctionTemplate>(constructor)).ToLocalChecked();
             Local<Value> ret = Nan::NewInstance(cons).ToLocalChecked();
-            Tree* host = ObjectWrap::Unwrap<Tree>(ret->ToObject());
+            Tree* host = ObjectWrap::Unwrap<Tree>(Nan::To<Object>(ret).ToLocalChecked());
             host->handle = tree;
             host->thread = false;
             return ret;


### PR DESCRIPTION
This pull request addresses `end-of-life` and `runtime` **deprecated API calls only**. The `end-of-life` deprecation made the package impossible to use starting from Node.js v.12.

Each type of deprecated API call is replaced with a new on by a separate commit, for convenience.

The `v8::Maybe::Check` method introduced in Node.js v.12 requires us to use at least Nan 2.14 to support the older versions of Node.js. Hence it's reflected in the `package.json`.

The structure and logic of the packaged remains intact.

I've used the updated package with success in a working project under Node.js versions 10.24, 12.22, 14.18 and 16.11.